### PR TITLE
Migrate from asciidoc to scdoc

### DIFF
--- a/.build.yml
+++ b/.build.yml
@@ -1,6 +1,6 @@
 image: alpine/latest
 packages:
-  - asciidoc
+  - scdoc
 sources:
   - https://github.com/KnightOS/kimg
 tasks:

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,3 @@
-CMakeCache.txt
-CMakeFiles
-cmake_install.cmake
-install_manifest.txt
 *.swp
 *.o
 bin/

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@ bin/kimg:main.o
 	mkdir -p bin/
 	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@
 
-bin/kimg.1:kimg.1.txt
-	a2x --no-xmllint --doctype manpage --format manpage kimg.1.txt -v -D bin/
+bin/kimg.1:kimg.1.scdoc
+	scdoc < kimg.1.scdoc > bin/kimg.1
 
 DESTDIR=/usr/local
 BINDIR=$(DESTDIR)/bin/

--- a/kimg.1.scdoc
+++ b/kimg.1.scdoc
@@ -1,60 +1,51 @@
-/////
-vim:set ts=4 sw=4 tw=82 noet:
-/////
-kimg (1)
-========
+KIMG(1)
 
-Name
-----
+# NAME
+
 kimg - KnightOS image conversion tool
 
-Synopsis
---------
-'kimg' [options] _input_ _output_
+# SYNOPSIS
 
-Description
------------
+*kimg* [options] _input_ _output_
+
+# DESCRIPTION
 
 Converts image formats supported by stb_image to the KnightOS image format.
 
-Options
--------
+# OPTIONS
 
-*-b, \--bare*::
+*-b, \--bare*
 	Omit the KIMG headers and write raw image data out.
 
-*-c, \--castle*::
+*-c, \--castle*
 	Implies -m, and -n and enforces the use of a 16x16 sprite.
 
-*-m, \--monochrome*::
+*-m, \--monochrome*
 	Converts the image to a monochrome KIMG file. Implies -p.
 
-*-n, \--no-compression*::
+*-n, \--no-compression*
 	Does not use (lossless) KIMG compression.
 
-*-p, \--no-palette*::
+*-p, \--no-palette*
 	Instruct kimg not to use a color palette.
 
-*-x, \--compression* <format>::
+*-x, \--compression* <format>
 	Uses the specified compression algorithm. The following options are available:
 	
-	* _NONE_
-	* _RLE_ (default)
+	- _NONE_
+	- _RLE_ (default)
 
-Examples
---------
+# EXAMPLES
 
-kimg example.png example.img::
+*kimg example.png example.img*
 	Converts example.png (portable network graphics) into example.img (kimg).
 
-Authors
--------
+# AUTHORS
 
 Maintained by Drew DeVault <sir@cmpwn.com>, who is assisted by other open
 source contributors. For more information about kimg development, see
-<https://github.com/KnightOS/kimg>.
+https://github.com/KnightOS/kimg.
 
-See Also
---------
+# SEE ALSO
 
-**convert**(1)
+*convert*(1)


### PR DESCRIPTION
Dumping asciidoc for the superior [scdoc](https://sr.ht/~sircmpwn/scdoc/).